### PR TITLE
Add bibify function

### DIFF
--- a/bibtex-database.sh
+++ b/bibtex-database.sh
@@ -78,6 +78,12 @@ else
 	echo "Supply a new or already existing database as argument"
 fi
 
+function bibify {
+ uri=${1/.pdf/}
+ uri=${uri/_/\/}
+ curl -s -LH "Accept: text/bibliography; style=bibtex" https://doi.org/$uri
+}
+
 
 
 


### PR DESCRIPTION
This function allows you to bibify a pdf directly (one at a time) given it's saved in the format `10.1111_111111.pdf`. It returns the `bib` to `stdout`.